### PR TITLE
Adds basic NPM packages file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "reveal-badges",
+  "version": "1.2.1",
+  "description": "Add badges to blocks in a reveal.js presentation",
+  "homepage": "http://thomas.weinert.info/reveal-badges/",
+  "license": "MIT",
+  "author": [
+    "Thomas Weinert <thomas@weinert.info>"
+  ],
+  "keywords": [
+    "reveal",
+    "badges",
+    "source"
+  ],
+  "files": [
+    "src/badges.js",
+    "src/badges.css"
+  ],
+  "ignore": [
+    "**/.*",
+    "doc",
+    "example"
+  ]
+}


### PR DESCRIPTION
One can install reveal.js using `npm install reveal.js`.

Because this package does not have a `package.json` file, it can not easily be installed with npm.

This pull request adds a `package.json` file, based on the bower file. 
 
Now this package can be installed using `npm install --save github:ThomasWeinert/reveal-badges`.

(No need to add the package to https://www.npmjs.com/ if you don't want to).