### PR TITLE
feature-optional-prefix-class-language

### DIFF
--- a/src/badges.js
+++ b/src/badges.js
@@ -1202,9 +1202,9 @@
         var properties = ['bg', 'fg', 'position', 'class'];
         var container = code.parentNode;
         var match, language, settings, i, attributeName;
-        var classString = code.getAttribute('class') || '';
-        if (match = classString.match(/\blanguage-(\S+)/)) {
-          language = match[1].toLowerCase();
+        var classString = code.getAttribute('class') || '';       
+        if ( match = classString.match(/\b(language-(\b))?\b(\S+)/) )  {        
+          language = match[3].toLowerCase();
 
           if (false === languages[language]) {
             return;
@@ -1230,7 +1230,7 @@
           } else {
             if (!container.getAttribute('data-badge')) {
               container.setAttribute(
-                'data-badge', match[1].toUpperCase()
+                'data-badge', language.toUpperCase()
               );
             }
           }

--- a/src/badges.js
+++ b/src/badges.js
@@ -1206,10 +1206,11 @@
         if ( match = classString.match(/\b(language-(\b))?\b(\S+)/) )  {        
           language = match[3].toLowerCase();
 
-          if (false === languages[language]) {
+          // return if class is 'hljs' (highlight.js)
+          if (false === languages[language] | language=='hljs') {
             return;
           }
-
+        
           if (settings = languages[language]) {
             if (!container.getAttribute('data-badge')) {
               container.setAttribute(


### PR DESCRIPTION
The patch should work with class="php hljs" or class="language-php hljs" or class="hljs"
I'm using [reveal-md](https://github.com/webpro/reveal-md) to generate slides from markdown and the code bloc class doesn't have prefix "language-"

I'm not sure about nested regexp but it works for my files

Example of generated bloc from markdown :
```
<pre>
<code class="php hljs">
...
</code>
</pre>
```
